### PR TITLE
Switch to System.Text.Json serialization (SWS-4542)

### DIFF
--- a/src/Shawarma.Abstractions/ApplicationState.cs
+++ b/src/Shawarma.Abstractions/ApplicationState.cs
@@ -1,6 +1,4 @@
 using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 
 // ReSharper disable once CheckNamespace
 namespace Shawarma
@@ -13,8 +11,6 @@ namespace Shawarma
         /// <summary>
         /// Status of the application.
         /// </summary>
-        [JsonProperty(PropertyName = "status")]
-        [JsonConverter(typeof(StringEnumConverter))]
         public ApplicationStatus Status { get; set; }
     }
 }

--- a/src/Shawarma.Abstractions/ApplicationStatus.cs
+++ b/src/Shawarma.Abstractions/ApplicationStatus.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Runtime.Serialization;
 
 // ReSharper disable once CheckNamespace
 namespace Shawarma
@@ -9,10 +8,7 @@ namespace Shawarma
     /// </summary>
     public enum ApplicationStatus
     {
-        [EnumMember(Value = "active")]
         Active,
-
-        [EnumMember(Value = "inactive")]
         Inactive
     }
 }

--- a/src/Shawarma.Abstractions/Shawarma.Abstractions.csproj
+++ b/src/Shawarma.Abstractions/Shawarma.Abstractions.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="5.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Shawarma.AspNetCore/Shawarma.AspNetCore.csproj
+++ b/src/Shawarma.AspNetCore/Shawarma.AspNetCore.csproj
@@ -25,6 +25,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
     <PackageReference Include="Microsoft.AspNetCore.Routing" Version="2.1.1" />
+    <PackageReference Include="System.Text.Json" Version="5.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Motivation
----------
Better alignment with .NET Core 3.1 and .NET 5. They currently use this
as the default, so we can avoid pulling in Newtonsoft.Json. Also, the
synchronous stream rendering causes problems without specific config
being in place in the app startup code.

Modifications
-------------
Drop Newtonsoft.Json and serialization settings from Abstractions.

Switch AspNetCore to use System.Text.Json, adding it as a dependency for
.NET Standard 2.0 only. Make serialization and deserialization async.

https://centeredge.atlassian.net/browse/SWS-4542
