### PR TITLE
Support trimming (ARCH-112)

### DIFF
--- a/Developing.md
+++ b/Developing.md
@@ -9,3 +9,17 @@ This project contains unit tests, and will be run with every build.
 This project may be run to test behaviors locally. Application state may be
 posted to <http://localhost:64007/applicationstate> as JSON. The console logs may
 be observed to see the `TestService` starting and stopping.
+
+### Testing trimming
+
+To test trimming support, publish the `Shawarma.AspNetCore.Test` application. This
+will produce warnings for any trimming issues.
+
+```sh
+dotnet publish -f net6.0 -r win10-x64 --self-contained ./src/Shawarma.AspNetCore.Test/Shawarma.AspNetCore.Test.csproj
+```
+
+However, note that warnings for ASP.NET assemblies will appear. This is because ASP.NET 6
+doesn't yet fully support trimming. We're doing this as future proofing for ASP.NET 7 which
+is planned to support trimming. So long as all of the warnings are for .NET assemblies and
+not Shawarma assemblies it is okay.

--- a/src/Shawarma.Abstractions/Shawarma.Abstractions.csproj
+++ b/src/Shawarma.Abstractions/Shawarma.Abstractions.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <IsTrimmable Condition=" '$(TargetFramework)' == 'net6.0' ">true</IsTrimmable>
 
     <Description>General abstractions for use within Shawarma.</Description>
   </PropertyGroup>

--- a/src/Shawarma.AspNetCore.Hosting/Shawarma.AspNetCore.Hosting.csproj
+++ b/src/Shawarma.AspNetCore.Hosting/Shawarma.AspNetCore.Hosting.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <IsTrimmable Condition=" '$(TargetFramework)' == 'net6.0' ">true</IsTrimmable>
 
     <Description>ASP.NET Core library for starting/stopping background services based on Shawarma application state.</Description>
   </PropertyGroup>

--- a/src/Shawarma.AspNetCore.Hosting/ShawarmaHostingServiceCollectionExtensions.cs
+++ b/src/Shawarma.AspNetCore.Hosting/ShawarmaHostingServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Shawarma.AspNetCore.Hosting
@@ -28,7 +29,11 @@ namespace Shawarma.AspNetCore.Hosting
         /// <typeparam name="TShawarmaService">An implementation of <see cref="IShawarmaService"/>.</typeparam>
         /// <param name="services">The <see cref="IServiceCollection"/>.</param>
         /// <returns>The <see cref="IServiceCollection"/>.</returns>
-        public static IServiceCollection AddShawarmaService<TShawarmaService>(this IServiceCollection services)
+        public static IServiceCollection AddShawarmaService<
+#if NET6_0_OR_GREATER
+            [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+#endif
+            TShawarmaService>(this IServiceCollection services)
             where TShawarmaService : class, IShawarmaService
             => services.AddTransient<IShawarmaService, TShawarmaService>();
     }

--- a/src/Shawarma.AspNetCore.Test/Shawarma.AspNetCore.Test.csproj
+++ b/src/Shawarma.AspNetCore.Test/Shawarma.AspNetCore.Test.csproj
@@ -4,11 +4,19 @@
     <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+    <PublishTrimmed>true</PublishTrimmed>
+    <!-- Prevent warnings from unused code in dependencies -->
+    <TrimmerDefaultAction>link</TrimmerDefaultAction>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Shawarma.AspNetCore.Hosting\Shawarma.AspNetCore.Hosting.csproj" />
     <ProjectReference Include="..\Shawarma.AspNetCore\Shawarma.AspNetCore.csproj" />
+
+    <!-- Analyze the whole library, even if attributed with "IsTrimmable" -->
+    <TrimmerRootAssembly Include="Shawarma.Abstractions" />
+    <TrimmerRootAssembly Include="Shawarma.AspNetCore" />
+    <TrimmerRootAssembly Include="Shawarma.AspNetCore.Hosting" />
   </ItemGroup>
 
 </Project>

--- a/src/Shawarma.AspNetCore/Shawarma.AspNetCore.csproj
+++ b/src/Shawarma.AspNetCore/Shawarma.AspNetCore.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <IsTrimmable Condition=" '$(TargetFramework)' == 'net6.0' ">true</IsTrimmable>
 
     <Description>ASP.NET Core Middleware for handling requests from Shawarma regarding application state.</Description>
   </PropertyGroup>


### PR DESCRIPTION
Motivation
----------
ASP.NET 7 is planned to support trimming, so we'd like to get ahead of
this and mark our assemblies as trimmable.

Modifications
-------------
Mark our assemblies as trimmable when targeting .NET 6 and add
annotations where required.

Configure `Shawarma.AspNetCore.Test` for trimming as a test platform.

https://centeredge.atlassian.net/browse/ARCH-112
