### PR TITLE
Mark middleware approach as obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ public class TestService : GenericShawarmaService
 
 ## Older .NET Core Versions
 
-Older versions of .NET Core are supported using middleware instead of endpoint routing.
+For applications not using endpoint routing, middleware may be used instead. However, this approach
+is considered obsolete.
 
 ```cs
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)

--- a/src/Shawarma.AspNetCore/Internal/ShawarmaConstants.cs
+++ b/src/Shawarma.AspNetCore/Internal/ShawarmaConstants.cs
@@ -1,9 +1,11 @@
-﻿using System;
+using System;
 
 namespace Shawarma.AspNetCore.Internal
 {
     internal static class ShawarmaConstants
     {
         public const string DefaultRouteTemplate = "applicationstate";
+
+        public const string UseEndpointRoutingWarning = "Use endpoint routing and MapShawarma() instead of middleware.";
     }
 }

--- a/src/Shawarma.AspNetCore/ShawarmaApplicationBuilderExtensions.cs
+++ b/src/Shawarma.AspNetCore/ShawarmaApplicationBuilderExtensions.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using Microsoft.AspNetCore.Builder;
+using Shawarma.AspNetCore.Internal;
 
 namespace Shawarma.AspNetCore
 {
@@ -13,6 +14,7 @@ namespace Shawarma.AspNetCore
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
         /// <returns>The <see cref="IApplicationBuilder"/>.</returns>
+        [Obsolete(ShawarmaConstants.UseEndpointRoutingWarning)]
         public static IApplicationBuilder UseShawarma(this IApplicationBuilder app)
         {
             if (app == null)
@@ -27,8 +29,10 @@ namespace Shawarma.AspNetCore
         /// Add <see cref="ShawarmaMiddleware"/> to the stack, using the default URL.
         /// </summary>
         /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
+        /// <param name="setupAction">Action to configure options.</param>
         /// <returns>The <see cref="IApplicationBuilder"/>.</returns>
-        public static IApplicationBuilder UseShawarma(this IApplicationBuilder app, Action<ShawarmaOptions> setupAction)
+        [Obsolete(ShawarmaConstants.UseEndpointRoutingWarning)]
+        public static IApplicationBuilder UseShawarma(this IApplicationBuilder app, Action<ShawarmaOptions>? setupAction)
         {
             if (app == null)
             {

--- a/src/Shawarma.AspNetCore/ShawarmaEndpointRouteBuilderExtensions.cs
+++ b/src/Shawarma.AspNetCore/ShawarmaEndpointRouteBuilderExtensions.cs
@@ -1,5 +1,3 @@
-#if !NETSTANDARD2_0
-
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
@@ -45,5 +43,3 @@ namespace Shawarma.AspNetCore
             });
     }
 }
-
-#endif

--- a/src/Shawarma.AspNetCore/ShawarmaMiddleware.cs
+++ b/src/Shawarma.AspNetCore/ShawarmaMiddleware.cs
@@ -4,17 +4,18 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Template;
 using Microsoft.Extensions.Options;
+using Shawarma.AspNetCore.Internal;
 
 namespace Shawarma.AspNetCore
 {
     /// <summary>
     /// Middleware component to intercept Shawarma-related requests.
     /// </summary>
+    [Obsolete(ShawarmaConstants.UseEndpointRoutingWarning)]
     public class ShawarmaMiddleware
     {
         private readonly RequestDelegate _next;
         private readonly IShawarmaRequestHandler _requestHandler;
-        private readonly ShawarmaOptions _options;
         private readonly TemplateMatcher _requestMatcher;
 
         public ShawarmaMiddleware(
@@ -32,7 +33,6 @@ namespace Shawarma.AspNetCore
         {
             _next = next;
             _requestHandler = requestHandler;
-            _options = options;
             _requestMatcher = new TemplateMatcher(TemplateParser.Parse(options.RouteTemplate),
                 options.RouteDefaults ?? new RouteValueDictionary());
         }


### PR DESCRIPTION
Motivation
----------
Now that we don't support the obsolete .NET Core 2.1 approach, most apps
should be using endpoint routing. As such, let's steer users towards
this more performant approach.

Modifications
-------------
Mark all externally facing APIs related to middleware as `Obsolete` and
update documentation.