### PR TITLE
Add library to easily use Shawarma from Aspire

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -3,6 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Aspire.Hosting" Version="13.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/Shawarma.AspNetCore.slnx
+++ b/src/Shawarma.AspNetCore.slnx
@@ -6,6 +6,7 @@
     <File Path="nuget.config" />
   </Folder>
   <Project Path="Shawarma.Abstractions/Shawarma.Abstractions.csproj" />
+  <Project Path="Shawarma.Aspire.Hosting/Shawarma.Aspire.Hosting.csproj" />
   <Project Path="Shawarma.AspNetCore.Hosting/Shawarma.AspNetCore.Hosting.csproj" />
   <Project Path="Shawarma.AspNetCore.Test/Shawarma.AspNetCore.Test.csproj" />
   <Project Path="Shawarma.AspNetCore/Shawarma.AspNetCore.csproj" />

--- a/src/Shawarma.Aspire.Hosting/Internal/ResourceSnapshotExtensions.cs
+++ b/src/Shawarma.Aspire.Hosting/Internal/ResourceSnapshotExtensions.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.CodeAnalysis;
+using Aspire.Hosting.ApplicationModel;
+
+namespace Shawarma.Aspire.Hosting.Internal;
+
+internal static class ResourceSnapshotExtensions
+{
+    private const string PropertyKey = "ShawarmaState";
+
+    extension(CustomResourceSnapshot snapshot)
+    {
+        public bool TryGetState([NotNullWhen(true)] out ApplicationState? state)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+
+            state = snapshot.Properties.FirstOrDefault(p => p.Name == PropertyKey)?.Value as ApplicationState;
+
+            return state is not null;
+        }
+
+        public CustomResourceSnapshot SetState(ApplicationState? state)
+        {
+            ArgumentNullException.ThrowIfNull(snapshot);
+
+            var newProperties = snapshot.Properties
+                .RemoveAll(p => p.Name == PropertyKey);
+
+            if (state is not null)
+            {
+                newProperties = newProperties.Add(new ResourcePropertySnapshot(PropertyKey, state));
+            }
+
+            if (snapshot.Properties.Equals(newProperties))
+            {
+                // No change
+                return snapshot;
+            }
+
+            return snapshot with
+            {
+                Properties = newProperties
+            };
+        }
+    }
+}

--- a/src/Shawarma.Aspire.Hosting/Internal/ShawarmaStateHandler.cs
+++ b/src/Shawarma.Aspire.Hosting/Internal/ShawarmaStateHandler.cs
@@ -1,0 +1,73 @@
+using System.Net.Http.Json;
+using Aspire.Hosting.ApplicationModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Shawarma.Aspire.Hosting.Internal;
+
+internal static class ShawarmaStateHandler
+{
+    private static readonly HttpClient HttpClient = new(new SocketsHttpHandler()
+    {
+        PooledConnectionIdleTimeout = TimeSpan.FromSeconds(5),
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2)
+    });
+
+    extension(EndpointReference endpoint)
+    {
+        private Uri ApplicationStateUri =>
+            new Uri(new Uri(endpoint.Url), "applicationstate");
+    }
+
+    public static async Task<ExecuteCommandResult> SetShawarmaStatusAsync(IServiceProvider serviceProvider, IResourceWithEndpoints resource, string endpointName, ApplicationStatus status, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(serviceProvider);
+        ArgumentNullException.ThrowIfNull(resource);
+        ArgumentException.ThrowIfNullOrEmpty(endpointName);
+
+        try
+        {
+            var newState = new ApplicationState()
+            {
+                Status = status,
+                ActiveServices = status == ApplicationStatus.Active ? ["default"] : []
+            };
+
+            var endpoint = resource.GetEndpoints()
+                .FirstOrDefault(endpoint => endpoint.EndpointName == endpointName);
+            if (endpoint is null)
+            {
+                return new ExecuteCommandResult() { Success = false, ErrorMessage = $"Endpoint '{endpointName}' not found." };
+            }
+
+            using var response = await HttpClient.PostAsJsonAsync(
+                endpoint.ApplicationStateUri,
+                newState,
+                cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                // Read the true new state from the response
+                newState = await response.Content.ReadFromJsonAsync<ApplicationState>(ShawarmaSerialization.ApplicationStateTypeInfo, cancellationToken: cancellationToken);
+
+                // Persist the state in the resource
+                var notificationService = serviceProvider.GetRequiredService<ResourceNotificationService>();
+                await notificationService.PublishUpdateAsync(resource,
+                    snapshot => snapshot.SetState(newState));
+
+                return new ExecuteCommandResult() { Success = true };
+            }
+            else
+            {
+                return new ExecuteCommandResult() { Success = false, ErrorMessage = $"Failed to set Shawarma services to '{status}'. Status code: {response.StatusCode}." };
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return new ExecuteCommandResult { Success = false, Canceled = true };
+        }
+        catch (Exception ex)
+        {
+            return new ExecuteCommandResult() { Success = false, ErrorMessage = $"Exception occurred while setting Shawarma services to '{status}': {ex.Message}" };
+        }
+    }
+}

--- a/src/Shawarma.Aspire.Hosting/Shawarma.Aspire.Hosting.csproj
+++ b/src/Shawarma.Aspire.Hosting/Shawarma.Aspire.Hosting.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+
+    <PackageTags>aspire integration hosting shawarma</PackageTags>
+    <Description>Shawarma support for Aspire.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Shawarma.Abstractions\Shawarma.Abstractions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Shawarma.Aspire.Hosting/ShawarmaResourceBuilderExtensions.cs
+++ b/src/Shawarma.Aspire.Hosting/ShawarmaResourceBuilderExtensions.cs
@@ -1,0 +1,75 @@
+using Aspire.Hosting;
+using Aspire.Hosting.ApplicationModel;
+using Shawarma.Aspire.Hosting.Internal;
+
+namespace Shawarma.Aspire.Hosting;
+
+/// <summary>
+/// Extensions for adding Shawarma support to resource builders.
+/// </summary>
+public static class ShawarmaResourceBuilderExtensions
+{
+    private const string DefaultEndpointName = "http";
+
+    /// <param name="builder">The <see cref="IResourceBuilder{T}"/>.</param>
+    extension<T>(IResourceBuilder<T> builder)
+        where T : IResourceWithEndpoints
+    {
+        /// <summary>
+        /// Add commands to enable and disable Shawarma services for the resource.
+        /// </summary>
+        /// <param name="endpointName">Name of the endpoint used to activate services, defaults to "http".</param>
+        /// <param name="autoStart">Automatically enable Shawarma services when the resource is ready.</param>
+        /// <returns>The <see cref="IResourceBuilder{T}"/>.</returns>
+        public IResourceBuilder<T> WithShawarma(string? endpointName = null, bool autoStart = false)
+        {
+            endpointName ??= DefaultEndpointName;
+
+            builder = builder
+                .WithCommand("shawarmaEnable", "Start Shawarma Services",
+                    context => ShawarmaStateHandler.SetShawarmaStatusAsync(context.ServiceProvider, builder.Resource, endpointName, ApplicationStatus.Active, context.CancellationToken),
+                    new CommandOptions()
+                    {
+                        IconName = "Play",
+                        UpdateState = context =>
+                        {
+                            if (!context.ResourceSnapshot.TryGetState(out var state))
+                            {
+                                return ResourceCommandState.Enabled;
+                            }
+
+                            return state.Status == ApplicationStatus.Active ? ResourceCommandState.Hidden : ResourceCommandState.Enabled;
+                        }
+                    })
+                .WithCommand("shawarmaDisable", "Stop Shawarma Services",
+                    context => ShawarmaStateHandler.SetShawarmaStatusAsync(context.ServiceProvider, builder.Resource, endpointName, ApplicationStatus.Inactive, context.CancellationToken),
+                    new CommandOptions()
+                    {
+                        IconName = "Stop",
+                        UpdateState = context =>
+                        {
+                            if (!context.ResourceSnapshot.TryGetState(out var state))
+                            {
+                                return ResourceCommandState.Hidden;
+                            }
+
+                            return state.Status == ApplicationStatus.Active ? ResourceCommandState.Enabled : ResourceCommandState.Hidden;
+                        }
+                    });
+
+            if (autoStart)
+            {
+                builder = builder.OnResourceReady(async (resource, e, cancellationToken) =>
+                {
+                    var result = await ShawarmaStateHandler.SetShawarmaStatusAsync(e.Services, resource, endpointName, ApplicationStatus.Active, cancellationToken);
+                    if (result is { Success: false, Canceled: false })
+                    {
+                        throw new InvalidOperationException($"Failed to enable Shawarma services on startup: {result.ErrorMessage}");
+                    }
+                });
+            }
+
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
Motivation
----------
We'd like a consistent means to start and stop Shwarma services manually from an Aspire AppHost and the Aspire Dashboard.

Modifications
-------------
Create the new Shawarma.Aspire.Hosting project which registers commands and can optionally autostart the Shawarma services when the resource is ready.